### PR TITLE
Add support for only uploading changed files

### DIFF
--- a/dist/classes/bunny-upload.js
+++ b/dist/classes/bunny-upload.js
@@ -7,13 +7,15 @@ exports["default"] = void 0;
 
 var _superagent = _interopRequireDefault(require("superagent"));
 
-var _fs = _interopRequireDefault(require("fs"));
+var _fsExtra = _interopRequireDefault(require("fs-extra"));
 
 var _path = _interopRequireDefault(require("path"));
 
 var _es6PromisePool = _interopRequireDefault(require("es6-promise-pool"));
 
 var _glob = _interopRequireDefault(require("glob"));
+
+var _mkdirp = _interopRequireDefault(require("mkdirp"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -38,6 +40,7 @@ var BunnyUpload = /*#__PURE__*/function () {
     var concurrency = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 10;
     var overwrite = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
     var storageZoneName = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'rex-cdn';
+    var onlyChanged = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
 
     _classCallCheck(this, BunnyUpload);
 
@@ -45,6 +48,7 @@ var BunnyUpload = /*#__PURE__*/function () {
     this.concurrency = concurrency;
     this.overwrite = overwrite;
     this.storageZoneName = storageZoneName;
+    this.onlyChanged = onlyChanged;
   }
 
   _createClass(BunnyUpload, [{
@@ -59,6 +63,40 @@ var BunnyUpload = /*#__PURE__*/function () {
       });
     }
   }, {
+    key: "getAllFiles",
+    value: function () {
+      var _getAllFiles = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(cwd) {
+        var files, toUpload;
+        return regeneratorRuntime.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                _context.next = 2;
+                return this.getAll(cwd);
+
+              case 2:
+                files = _context.sent;
+                toUpload = files.filter(function (f) {
+                  var p = "".concat(cwd, "/").concat(f);
+                  return !_fsExtra["default"].lstatSync(p).isDirectory();
+                });
+                return _context.abrupt("return", toUpload);
+
+              case 5:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee, this);
+      }));
+
+      function getAllFiles(_x) {
+        return _getAllFiles.apply(this, arguments);
+      }
+
+      return getAllFiles;
+    }()
+  }, {
     key: "get",
     value: function get(storageZoneName, p2, fileName) {
       return _superagent["default"].get("https://la.storage.bunnycdn.com/".concat(storageZoneName, "/").concat(p2, "/").concat(fileName)).set('AccessKey', this.key);
@@ -69,13 +107,81 @@ var BunnyUpload = /*#__PURE__*/function () {
       return _superagent["default"].put("https://la.storage.bunnycdn.com/".concat(storageZoneName, "/").concat(p2, "/").concat(fileName)).set('AccessKey', this.key).send(buffer);
     }
   }, {
+    key: "readFileAndPut",
+    value: function () {
+      var _readFileAndPut = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(p, p2, fileName, hasBackupFile) {
+        var buffer, localDirBackupBuffer, notChanged, res;
+        return regeneratorRuntime.wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                buffer = _fsExtra["default"].readFileSync(p);
+
+                if (!hasBackupFile) {
+                  _context2.next = 11;
+                  break;
+                }
+
+                localDirBackupBuffer = _fsExtra["default"].readFileSync(".bunny-upload/".concat(p));
+                notChanged = buffer.equals(localDirBackupBuffer); // Checks if the /dist file has the same contents as the backup
+
+                if (!(notChanged != false)) {
+                  _context2.next = 8;
+                  break;
+                }
+
+                return _context2.abrupt("return");
+
+              case 8:
+                console.log("FILE CHANGE: ".concat(fileName));
+
+              case 9:
+                _context2.next = 12;
+                break;
+
+              case 11:
+                console.log("Uploading: ".concat(p));
+
+              case 12:
+                _context2.prev = 12;
+                _context2.next = 15;
+                return this.put(this.storageZoneName, p2, fileName, buffer);
+
+              case 15:
+                res = _context2.sent;
+                this.purge(res.request.url);
+                _context2.next = 23;
+                break;
+
+              case 19:
+                _context2.prev = 19;
+                _context2.t0 = _context2["catch"](12);
+                console.log('FAILED: ' + p);
+                console.log(_context2.t0);
+
+              case 23:
+              case "end":
+                return _context2.stop();
+            }
+          }
+        }, _callee2, this, [[12, 19]]);
+      }));
+
+      function readFileAndPut(_x2, _x3, _x4, _x5) {
+        return _readFileAndPut.apply(this, arguments);
+      }
+
+      return readFileAndPut;
+    }() // hasBackupFile = true only if this.onlyChanged = true && file exists
+
+  }, {
     key: "upload",
     value: function () {
-      var _upload = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(localDir, file, cdnPath) {
-        var p, paths, fileName, subdirs, subdir, p2, res, buffer;
-        return regeneratorRuntime.wrap(function _callee$(_context) {
+      var _upload = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3(localDir, hasBackupFile, file, cdnPath) {
+        var p, paths, fileName, subdirs, subdir, p2, res;
+        return regeneratorRuntime.wrap(function _callee3$(_context3) {
           while (1) {
-            switch (_context.prev = _context.next) {
+            switch (_context3.prev = _context3.next) {
               case 0:
                 p = "".concat(localDir, "/").concat(file);
                 paths = file.split('/');
@@ -83,81 +189,50 @@ var BunnyUpload = /*#__PURE__*/function () {
                 subdirs = file.split('/').slice(0, paths.length - 1);
                 subdir = subdirs.join('/');
                 p2 = subdirs.length > 0 ? "".concat(cdnPath, "/").concat(subdir) : "".concat(cdnPath);
-                _context.prev = 6;
-                _context.next = 9;
-                return this.get(this.storageZoneName, p2, fileName);
-
-              case 9:
-                res = _context.sent;
+                _context3.prev = 6;
 
                 if (!this.overwrite) {
-                  _context.next = 26;
+                  _context3.next = 12;
                   break;
                 }
 
-                console.log("Uploading: ".concat(p));
-                buffer = _fs["default"].readFileSync(p);
-                _context.prev = 13;
-                _context.next = 16;
-                return this.put(this.storageZoneName, p2, fileName, buffer);
+                _context3.next = 10;
+                return this.readFileAndPut(p, p2, fileName, hasBackupFile);
 
-              case 16:
-                res = _context.sent;
-                this.purge(res.request.url);
-                _context.next = 24;
+              case 10:
+                _context3.next = 16;
                 break;
 
-              case 20:
-                _context.prev = 20;
-                _context.t0 = _context["catch"](13);
-                console.log('FAILED: ' + p);
-                console.log(_context.t0);
+              case 12:
+                _context3.next = 14;
+                return this.get(this.storageZoneName, p2, fileName);
 
-              case 24:
-                _context.next = 27;
-                break;
-
-              case 26:
+              case 14:
+                res = _context3.sent;
                 console.log("Skipping: ".concat(p));
 
-              case 27:
-                _context.next = 44;
+              case 16:
+                _context3.next = 22;
                 break;
 
-              case 29:
-                _context.prev = 29;
-                _context.t1 = _context["catch"](6);
-                // Not found, upload
-                buffer = _fs["default"].readFileSync(p);
-                console.log("Uploading: ".concat(p));
-                _context.prev = 33;
-                _context.next = 36;
-                return this.put(this.storageZoneName, p2, fileName, buffer);
+              case 18:
+                _context3.prev = 18;
+                _context3.t0 = _context3["catch"](6);
+                _context3.next = 22;
+                return this.readFileAndPut(p, p2, fileName, hasBackupFile);
 
-              case 36:
-                res = _context.sent;
-                this.purge(res.request.url);
-                _context.next = 44;
-                break;
+              case 22:
+                return _context3.abrupt("return", true);
 
-              case 40:
-                _context.prev = 40;
-                _context.t2 = _context["catch"](33);
-                console.log('FAILED: ' + p);
-                console.log(_context.t2);
-
-              case 44:
-                return _context.abrupt("return", true);
-
-              case 45:
+              case 23:
               case "end":
-                return _context.stop();
+                return _context3.stop();
             }
           }
-        }, _callee, this, [[6, 29], [13, 20], [33, 40]]);
+        }, _callee3, this, [[6, 18]]);
       }));
 
-      function upload(_x, _x2, _x3) {
+      function upload(_x6, _x7, _x8, _x9) {
         return _upload.apply(this, arguments);
       }
 
@@ -166,37 +241,37 @@ var BunnyUpload = /*#__PURE__*/function () {
   }, {
     key: "purge",
     value: function () {
-      var _purge = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(cdnUrl) {
+      var _purge = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4(cdnUrl) {
         var res;
-        return regeneratorRuntime.wrap(function _callee2$(_context2) {
+        return regeneratorRuntime.wrap(function _callee4$(_context4) {
           while (1) {
-            switch (_context2.prev = _context2.next) {
+            switch (_context4.prev = _context4.next) {
               case 0:
                 console.log("Purging file: ".concat(cdnUrl));
-                _context2.prev = 1;
-                _context2.next = 4;
+                _context4.prev = 1;
+                _context4.next = 4;
                 return this.purgeFile(cdnUrl);
 
               case 4:
-                res = _context2.sent;
-                _context2.next = 11;
+                res = _context4.sent;
+                _context4.next = 11;
                 break;
 
               case 7:
-                _context2.prev = 7;
-                _context2.t0 = _context2["catch"](1);
+                _context4.prev = 7;
+                _context4.t0 = _context4["catch"](1);
                 console.log('FAILED: ' + p);
-                console.log(_context2.t0);
+                console.log(_context4.t0);
 
               case 11:
               case "end":
-                return _context2.stop();
+                return _context4.stop();
             }
           }
-        }, _callee2, this, [[1, 7]]);
+        }, _callee4, this, [[1, 7]]);
       }));
 
-      function purge(_x4) {
+      function purge(_x10) {
         return _purge.apply(this, arguments);
       }
 
@@ -216,89 +291,137 @@ var BunnyUpload = /*#__PURE__*/function () {
     }
   }, {
     key: "generatePromises",
-    value: /*#__PURE__*/regeneratorRuntime.mark(function generatePromises(toUpload, localDir, cdnPath) {
-      var _iterator, _step, file;
+    value: /*#__PURE__*/regeneratorRuntime.mark(function generatePromises(toUpload, localDirBackupFiles, localDir, cdnPath) {
+      var _iterator, _step, file, hasBackupFile;
 
-      return regeneratorRuntime.wrap(function generatePromises$(_context3) {
+      return regeneratorRuntime.wrap(function generatePromises$(_context5) {
         while (1) {
-          switch (_context3.prev = _context3.next) {
+          switch (_context5.prev = _context5.next) {
             case 0:
               _iterator = _createForOfIteratorHelper(toUpload);
-              _context3.prev = 1;
+              _context5.prev = 1;
 
               _iterator.s();
 
             case 3:
               if ((_step = _iterator.n()).done) {
-                _context3.next = 9;
+                _context5.next = 11;
                 break;
               }
 
               file = _step.value;
-              _context3.next = 7;
-              return this.upload(localDir, file, cdnPath);
+              hasBackupFile = false;
 
-            case 7:
-              _context3.next = 3;
-              break;
+              if (localDirBackupFiles != false) {
+                hasBackupFile = localDirBackupFiles.indexOf(file) != -1;
+              }
+
+              _context5.next = 9;
+              return this.upload(localDir, hasBackupFile, file, cdnPath);
 
             case 9:
-              _context3.next = 14;
+              _context5.next = 3;
               break;
 
             case 11:
-              _context3.prev = 11;
-              _context3.t0 = _context3["catch"](1);
+              _context5.next = 16;
+              break;
 
-              _iterator.e(_context3.t0);
+            case 13:
+              _context5.prev = 13;
+              _context5.t0 = _context5["catch"](1);
 
-            case 14:
-              _context3.prev = 14;
+              _iterator.e(_context5.t0);
+
+            case 16:
+              _context5.prev = 16;
 
               _iterator.f();
 
-              return _context3.finish(14);
+              return _context5.finish(16);
 
-            case 17:
+            case 19:
             case "end":
-              return _context3.stop();
+              return _context5.stop();
           }
         }
-      }, generatePromises, this, [[1, 11, 14, 17]]);
+      }, generatePromises, this, [[1, 13, 16, 19]]);
     })
+  }, {
+    key: "storeLocalDirBackup",
+    value: function storeLocalDirBackup(localDir) {
+      try {
+        var made = _mkdirp["default"].sync('.bunny-upload'); // Ensure the folder exists
+
+
+        _fsExtra["default"].emptyDirSync('.bunny-upload/dist'); // Delete the backup files
+
+
+        _fsExtra["default"].copySync(localDir, '.bunny-upload/dist', {
+          overwrite: true
+        }); // Create the backup
+
+      } catch (err) {
+        // If this ever fails it probably doesn't need fixing
+        return err;
+      }
+
+      return true;
+    }
   }, {
     key: "s2",
     value: function () {
-      var _s = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3(localDir, cdnPath, concurrency) {
-        var files, toUpload, promiseIterator, pool;
-        return regeneratorRuntime.wrap(function _callee3$(_context4) {
+      var _s = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee5(localDir, cdnPath, concurrency) {
+        var _this = this;
+
+        var toUpload, localDirBackupFiles, promiseIterator, pool;
+        return regeneratorRuntime.wrap(function _callee5$(_context6) {
           while (1) {
-            switch (_context4.prev = _context4.next) {
+            switch (_context6.prev = _context6.next) {
               case 0:
-                _context4.next = 2;
-                return this.getAll(localDir);
+                _context6.next = 2;
+                return this.getAllFiles(localDir);
 
               case 2:
-                files = _context4.sent;
-                toUpload = files.filter(function (f) {
-                  var p = "".concat(localDir, "/").concat(f);
-                  return !_fs["default"].lstatSync(p).isDirectory();
-                });
-                promiseIterator = this.generatePromises(toUpload, localDir, cdnPath);
-                pool = new _es6PromisePool["default"](promiseIterator, concurrency);
-                return _context4.abrupt("return", pool.start().then(function () {
-                  return console.log('Complete');
-                }));
+                toUpload = _context6.sent;
+                localDirBackupFiles = false;
+
+                if (!(this.onlyChanged === true)) {
+                  _context6.next = 8;
+                  break;
+                }
+
+                _context6.next = 7;
+                return this.getAllFiles('.bunny-upload/dist');
 
               case 7:
+                localDirBackupFiles = _context6.sent;
+
+              case 8:
+                promiseIterator = this.generatePromises(toUpload, localDirBackupFiles, localDir, cdnPath);
+                pool = new _es6PromisePool["default"](promiseIterator, concurrency);
+                return _context6.abrupt("return", pool.start().then(function () {
+                  console.log('Complete'); // Create the .bunny-upload folder & move /dist into it
+
+                  if (_this.onlyChanged === true) {
+                    var backupStatus = _this.storeLocalDirBackup(localDir);
+
+                    if (backupStatus != true) {
+                      console.warn('The local dir backup ran into an issue:');
+                      console.error(backupStatus);
+                    }
+                  }
+                }));
+
+              case 11:
               case "end":
-                return _context4.stop();
+                return _context6.stop();
             }
           }
-        }, _callee3, this);
+        }, _callee5, this);
       }));
 
-      function s2(_x5, _x6, _x7) {
+      function s2(_x11, _x12, _x13) {
         return _s.apply(this, arguments);
       }
 

--- a/dist/classes/bunny-upload.js
+++ b/dist/classes/bunny-upload.js
@@ -122,7 +122,7 @@ var BunnyUpload = /*#__PURE__*/function () {
                   break;
                 }
 
-                localDirBackupBuffer = _fsExtra["default"].readFileSync(".bunny-upload/".concat(p));
+                localDirBackupBuffer = _fsExtra["default"].readFileSync(".bunny-upload/backup/".concat(p));
                 notChanged = buffer.equals(localDirBackupBuffer); // Checks if the /dist file has the same contents as the backup
 
                 if (!(notChanged != false)) {
@@ -354,10 +354,10 @@ var BunnyUpload = /*#__PURE__*/function () {
         var made = _mkdirp["default"].sync('.bunny-upload'); // Ensure the folder exists
 
 
-        _fsExtra["default"].emptyDirSync('.bunny-upload/dist'); // Delete the backup files
+        _fsExtra["default"].emptyDirSync(".bunny-upload/backup/".concat(localDir)); // Delete the backup files
 
 
-        _fsExtra["default"].copySync(localDir, '.bunny-upload/dist', {
+        _fsExtra["default"].copySync(localDir, ".bunny-upload/backup/".concat(localDir), {
           overwrite: true
         }); // Create the backup
 
@@ -392,7 +392,7 @@ var BunnyUpload = /*#__PURE__*/function () {
                 }
 
                 _context6.next = 7;
-                return this.getAllFiles('.bunny-upload/dist');
+                return this.getAllFiles(".bunny-upload/backup/".concat(localDir));
 
               case 7:
                 localDirBackupFiles = _context6.sent;

--- a/dist/example.js
+++ b/dist/example.js
@@ -12,6 +12,7 @@ var res = (0, _index["default"])({
   cdnDir: 'test-1',
   concurrency: 2,
   overwrite: true,
-  storageZoneName: 'diego-test'
+  storageZoneName: 'diego-test',
+  onlyChanged: true
 }); // var bu = new BunnyUpload();
 // console.log();

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,14 +53,18 @@ function _bunnyUpload() {
               options.storageZoneName = 'rex-cdn'; //or better and env variable
             }
 
-            bunny = new _bunnyUpload2["default"](options.key, options.concurrency, options.overwrite, options.storageZoneName);
-            _context.next = 7;
+            if (options.onlyChanged === undefined) {
+              options.onlyChanged = false; // Uploads only new files to bunny when true
+            }
+
+            bunny = new _bunnyUpload2["default"](options.key, options.concurrency, options.overwrite, options.storageZoneName, options.onlyChanged);
+            _context.next = 8;
             return bunny.s2(options.localDir, options.cdnDir, options.concurrency);
 
-          case 7:
+          case 8:
             return _context.abrupt("return", _context.sent);
 
-          case 8:
+          case 9:
           case "end":
             return _context.stop();
         }

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "validate.js": "^0.13.1",
     "core-js": "^3.8.3",
     "es6-promise-pool": "^2.5.0",
-    "fs": "^0.0.1-security",
+    "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
+    "mkdirp": "^1.0.4",
     "path": "^0.12.7",
     "regenerator-runtime": "^0.13.7",
-    "superagent": "^6.1.0"
+    "superagent": "^6.1.0",
+    "validate.js": "^0.13.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/src/classes/bunny-upload.js
+++ b/src/classes/bunny-upload.js
@@ -48,7 +48,7 @@ export default class BunnyUpload {
 	async readFileAndPut(p, p2, fileName, hasBackupFile) {
 		let buffer = fs.readFileSync(p);
 		if(hasBackupFile){
-			let localDirBackupBuffer = fs.readFileSync(`.bunny-upload/${p}`);
+			let localDirBackupBuffer = fs.readFileSync(`.bunny-upload/backup/${p}`);
 			let notChanged = buffer.equals(localDirBackupBuffer); // Checks if the /dist file has the same contents as the backup
 			if(notChanged != false){
 				return;
@@ -132,8 +132,8 @@ export default class BunnyUpload {
 	storeLocalDirBackup(localDir) {
 		try {
 			const made = mkdirp.sync('.bunny-upload'); // Ensure the folder exists
-			fs.emptyDirSync('.bunny-upload/dist'); // Delete the backup files
-			fs.copySync(localDir, '.bunny-upload/dist', { overwrite: true }); // Create the backup
+			fs.emptyDirSync(`.bunny-upload/backup/${localDir}`); // Delete the backup files
+			fs.copySync(localDir, `.bunny-upload/backup/${localDir}`, { overwrite: true }); // Create the backup
 		} catch (err) {
 			// If this ever fails it probably doesn't need fixing
 			return err;
@@ -146,7 +146,7 @@ export default class BunnyUpload {
 
 		let localDirBackupFiles = false;
 		if (this.onlyChanged === true) {
-			localDirBackupFiles = await this.getAllFiles('.bunny-upload/dist');
+			localDirBackupFiles = await this.getAllFiles(`.bunny-upload/backup/${localDir}`);
 		}
 
 		const promiseIterator = this.generatePromises(toUpload, localDirBackupFiles, localDir, cdnPath);

--- a/src/classes/bunny-upload.js
+++ b/src/classes/bunny-upload.js
@@ -1,91 +1,111 @@
 import superagent from 'superagent';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import PromisePool from 'es6-promise-pool';
 import glob from 'glob';
+import mkdirp from 'mkdirp';
 
 export default class BunnyUpload {
-	constructor(key, concurrency = 10, overwrite = false, storageZoneName = 'rex-cdn') {
+	constructor(key, concurrency = 10, overwrite = false, storageZoneName = 'rex-cdn', onlyChanged = false) {
 		this.key = key;
 		this.concurrency = concurrency;
 		this.overwrite = overwrite;
 		this.storageZoneName = storageZoneName;
+		this.onlyChanged = onlyChanged;
 	}
 
 	getAll(cwd) {
-	    return new Promise((res) => {
-	        glob( `**/*`, {
-	            cwd
-	        }, (err, files) => {
-	            res(files);
-	        });
-	    })
+		return new Promise((res) => {
+			glob(`**/*`, {
+				cwd
+			}, (err, files) => {
+				res(files);
+			});
+		})
+	}
+	async getAllFiles(cwd) {
+		let files = await this.getAll(cwd);
+		let toUpload = files.filter((f) => {
+			let p = `${cwd}/${f}`;
+			return !fs.lstatSync(p).isDirectory();
+		});
+		return toUpload;
 	}
 
 	get(storageZoneName, p2, fileName) {
-	    return superagent
-	        .get(`https://la.storage.bunnycdn.com/${storageZoneName}/${p2}/${fileName}`)
-	        .set('AccessKey', this.key);
+		return superagent
+			.get(`https://la.storage.bunnycdn.com/${storageZoneName}/${p2}/${fileName}`)
+			.set('AccessKey', this.key);
 	}
 
- 	put(storageZoneName, p2, fileName, buffer) {
-	    return superagent
-	        .put(`https://la.storage.bunnycdn.com/${storageZoneName}/${p2}/${fileName}`)
-	        .set('AccessKey', this.key)
-	        .send(buffer);
+	put(storageZoneName, p2, fileName, buffer) {
+		return superagent
+			.put(`https://la.storage.bunnycdn.com/${storageZoneName}/${p2}/${fileName}`)
+			.set('AccessKey', this.key)
+			.send(buffer);
 	}
 
-	async upload(localDir, file, cdnPath) {
-	    let p = `${localDir}/${file}`;
-	    let paths = file.split('/');
-	    let fileName = paths.slice(-1)[0];
-	    let subdirs = file.split('/').slice(0, paths.length - 1);
-	    let subdir = subdirs.join('/');
-	    let p2 = subdirs.length > 0 ? `${cdnPath}/${subdir}` : `${cdnPath}`;
-	    let res;
-
-	    try {
-	        res = await this.get(this.storageZoneName, p2, fileName)
-	        if(this.overwrite){
-	        	console.log(`Uploading: ${p}`);
-				var buffer = fs.readFileSync(p);
-				try {
-					res = await this.put(this.storageZoneName, p2, fileName, buffer);
-					this.purge(res.request.url);
-				} catch (e) {
-					console.log('FAILED: ' + p);
-					console.log(e);
-				}
-	        }else{
-	        	console.log(`Skipping: ${p}`);
-	        }
-	    } catch (e) {
-	        // Not found, upload
-	        var buffer = fs.readFileSync(p);
-	        console.log(`Uploading: ${p}`);
-	        try {
-	            res = await this.put(this.storageZoneName, p2, fileName, buffer);
-				this.purge(res.request.url);
-	        } catch (e) {
-	            console.log('FAILED: ' + p);
-	            console.log(e);
-	        }
-	    }
-	    return true;
+	async readFileAndPut(p, p2, fileName, hasBackupFile) {
+		let buffer = fs.readFileSync(p);
+		if(hasBackupFile){
+			let localDirBackupBuffer = fs.readFileSync(`.bunny-upload/${p}`);
+			let notChanged = buffer.equals(localDirBackupBuffer); // Checks if the /dist file has the same contents as the backup
+			if(notChanged != false){
+				return;
+			} else {
+				console.log(`FILE CHANGE: ${fileName}`);
+			}
+		} else {
+			console.log(`Uploading: ${p}`);
+		}
+		
+		try {
+			let res = await this.put(this.storageZoneName, p2, fileName, buffer);
+			this.purge(res.request.url);
+		} catch (e) {
+			console.log('FAILED: ' + p);
+			console.log(e);
+		}
 	}
 
-	async purge(cdnUrl){
+	// hasBackupFile = true only if this.onlyChanged = true && file exists
+	async upload(localDir, hasBackupFile, file, cdnPath) {
+		let p = `${localDir}/${file}`;
+		let paths = file.split('/');
+		let fileName = paths.slice(-1)[0];
+		let subdirs = file.split('/').slice(0, paths.length - 1);
+		let subdir = subdirs.join('/');
+		let p2 = subdirs.length > 0 ? `${cdnPath}/${subdir}` : `${cdnPath}`;
+		let res;
+
+		try {
+			if (this.overwrite) {
+				await this.readFileAndPut(p, p2, fileName, hasBackupFile);
+			} else {
+				// Moved this to avoid unnecessary API calls on overwrite = true
+				res = await this.get(this.storageZoneName, p2, fileName);
+
+				console.log(`Skipping: ${p}`);
+			}
+		} catch (e) {
+			// Not found, upload
+			await this.readFileAndPut(p, p2, fileName, hasBackupFile);
+		}
+		return true;
+	}
+
+	async purge(cdnUrl) {
 		console.log(`Purging file: ${cdnUrl}`);
 		let res;
 		try {
-		    res = await this.purgeFile(cdnUrl);
-        } catch (e) {
-            console.log('FAILED: ' + p);
-            console.log(e);
-        }
+			res = await this.purgeFile(cdnUrl);
+		} catch (e) {
+			console.log('FAILED: ' + p);
+			console.log(e);
+		}
 	}
 
-	purgeFile(cdnUrl){
+	purgeFile(cdnUrl) {
 
 		//TODO: actually build this functionality out (cdn endpoint in by param)
 		// https://la.storage.bunnycdn.com/rex-cdn
@@ -94,32 +114,58 @@ export default class BunnyUpload {
 		console.log(`Purging: ${cdnUrl}`);
 
 		return superagent
-		        .post("https://bunnycdn.com/api/purge")
-		        .set('AccessKey', this.key)
-		        .send({url: cdnUrl});
+			.post("https://bunnycdn.com/api/purge")
+			.set('AccessKey', this.key)
+			.send({ url: cdnUrl });
 	}
 
-	* generatePromises(toUpload, localDir, cdnPath){
-
+	* generatePromises(toUpload, localDirBackupFiles, localDir, cdnPath) {
 		for (let file of toUpload) {
-			yield this.upload(localDir, file, cdnPath);
+			let hasBackupFile = false;
+			if (localDirBackupFiles != false) {
+				hasBackupFile = localDirBackupFiles.indexOf(file) != -1;
+			}
+			yield this.upload(localDir, hasBackupFile, file, cdnPath);
 		}
+	}
 
+	storeLocalDirBackup(localDir) {
+		try {
+			const made = mkdirp.sync('.bunny-upload'); // Ensure the folder exists
+			fs.emptyDirSync('.bunny-upload/dist'); // Delete the backup files
+			fs.copySync(localDir, '.bunny-upload/dist', { overwrite: true }); // Create the backup
+		} catch (err) {
+			// If this ever fails it probably doesn't need fixing
+			return err;
+		}
+		return true;
 	}
 
 	async s2(localDir, cdnPath, concurrency) {
-	    let files = await this.getAll(localDir);
-	    let toUpload = files.filter((f) => {
-	        let p = `${localDir}/${f}`;
-	        return !fs.lstatSync(p).isDirectory();
-	    });
+		const toUpload = await this.getAllFiles(localDir);
 
-	    const promiseIterator = this.generatePromises(toUpload, localDir, cdnPath);
+		let localDirBackupFiles = false;
+		if (this.onlyChanged === true) {
+			localDirBackupFiles = await this.getAllFiles('.bunny-upload/dist');
+		}
 
-	    const pool = new PromisePool(promiseIterator, concurrency);
+		const promiseIterator = this.generatePromises(toUpload, localDirBackupFiles, localDir, cdnPath);
 
-	    return pool.start()
-	        .then(() => console.log('Complete'));
+		const pool = new PromisePool(promiseIterator, concurrency);
+
+		return pool.start()
+			.then(() => {
+				console.log('Complete');
+
+				// Create the .bunny-upload folder & move /dist into it
+				if (this.onlyChanged === true) {
+					const backupStatus = this.storeLocalDirBackup(localDir);
+					if (backupStatus != true) {
+						console.warn('The local dir backup ran into an issue:');
+						console.error(backupStatus);
+					}
+				}
+			});
 
 	}
 }

--- a/src/example.js
+++ b/src/example.js
@@ -7,7 +7,8 @@ let res = bunnyUpload({
     cdnDir: 'test-1',
     concurrency: 2,
     overwrite: true,
-    storageZoneName: 'diego-test'
+    storageZoneName: 'diego-test',
+	onlyChanged: true
 });
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,11 @@ export default async function bunnyUpload(options){
 		options.storageZoneName = 'rex-cdn'; //or better and env variable
 	}
 
-	var bunny = new BunnyUpload(options.key, options.concurrency, options.overwrite, options.storageZoneName);
+	if(options.onlyChanged === undefined){
+		options.onlyChanged = false; // Uploads only new files to bunny when true
+	}
+
+	var bunny = new BunnyUpload(options.key, options.concurrency, options.overwrite, options.storageZoneName, options.onlyChanged);
 	return await bunny.s2(options.localDir, options.cdnDir, options.concurrency);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1883,6 +1888,16 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -1892,11 +1907,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
 
 fsevents@~2.3.1:
   version "2.3.1"
@@ -1973,6 +1983,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2265,6 +2280,15 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2426,6 +2450,11 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -3150,6 +3179,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hello! I don't mean to interfere. I believe I may have ran into some rate limit issues the past few days so I implemented this. 

<img width="506" alt="Screen Shot 2021-02-14 at 7 49 10 PM" src="https://user-images.githubusercontent.com/7343076/107894483-c1ac2e00-6efd-11eb-8dc7-772c003a6101.png">

I added a parameter called "onlyChanged" to the accepted input. When specified as true, every completion it will backup the "localDir" folder and use this to detect files with content changes. If unspecified, it will work as normal.

&nbsp;

<img width="671" alt="Screen Shot 2021-02-14 at 7 47 53 PM" src="https://user-images.githubusercontent.com/7343076/107894398-90336280-6efd-11eb-96d2-85ca31d73026.png">
I also moved the BunnyCDN GET function call to eliminate an unnecessary API request per file when "overwrite = true".
  
&nbsp;

I tried to change as little as possible & match your coding style. Quite a few of the line changes were unfortunately from an auto format. If you think the modification looks good I would greatly appreciate getting this merged!